### PR TITLE
Downgrading grafana-toolkit version to pass ci-tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@grafana/data": "^7.4.2",
     "@grafana/runtime": "7.4.2",
-    "@grafana/toolkit": "^7.5.7",
+    "@grafana/toolkit": "7.4.2",
     "@grafana/ui": "7.4.2",
     "@types/lodash": "^4.14.134",
     "lodash": "^4.17.15"


### PR DESCRIPTION
After upgrading the Grafana-toolkit package, Circle CI fails. As the duplicates errors are now solved, it is OK to downgrade.