### PR TITLE
Bump to version 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,6 @@
 - Added Alarms and Events; historic and subscription
 - Config UI and persistence have been changed, not backwards compatible
 - Added support for dashboard mapping from instance/type. This is to support complementary Grafana panel plugins at https://github.com/PrediktorAS/grafana
+
+## [1.1.2] - 2021-06-10
+- Mostly fixes needed for Successfully registering in the Grafana Plugin Registry

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-opcua-datasource",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Reads data from OPC UA Servers",
   "scripts": {
     "build": "grafana-toolkit plugin:build",


### PR DESCRIPTION
The process of registering to the Grafana Plugin registry found issues in the apps ID. A change in version is needed to mitigate.